### PR TITLE
Update: remove prettier-eslint conflicts

### DIFF
--- a/packages/eslint-config-yc-base/README.md
+++ b/packages/eslint-config-yc-base/README.md
@@ -18,7 +18,7 @@ It inherits some basic packages like:
   ```
   module.exports = {
     extends: [
-      'yc-base'
+      '@youngcapital/eslint-config-yc-base'
     ]
   };
   ```
@@ -26,7 +26,7 @@ It inherits some basic packages like:
   ```
   {
     "eslintConfig": {
-      "extends": "yc-base"
+      "extends": "@youngcapital/eslint-config-yc-base"
     }
   }
   ```

--- a/packages/eslint-config-yc-base/package.json
+++ b/packages/eslint-config-yc-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@youngcapital/eslint-config-yc-base",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "index.js",
   "author": "YoungCapital",
   "license": "ISC",

--- a/packages/eslint-config-yc-base/rules/rules.js
+++ b/packages/eslint-config-yc-base/rules/rules.js
@@ -8,8 +8,10 @@ module.exports = {
     'function-paren-newline': 'off',
     'import/no-extraneous-dependencies': 'off',
     'import/prefer-default-export': 'error',
+    'implicit-arrow-linebreak': 'off',
     'max-len': ['error', { code: 120 }],
     'no-console': 'error',
+    'no-confusing-arrow': 'off',
     'no-debugger': 'error',
     'no-mixed-operators': 'error',
     'no-multi-spaces': 'error',
@@ -24,17 +26,21 @@ module.exports = {
     'no-unused-vars': 'error',
     'no-use-before-define': ['error', 'nofunc'], // functions are hoisted
     'object-curly-newline': 'off',
-    'object-curly-spacing': ['error', 'always'],
+    'template-curly-spacing': 'off',
     'one-var': 'off',
-    'operator-linebreak': ['error', 'after'],
+    'operator-linebreak': 'off',
     'prefer-const': 'error',
     'prefer-rest-params': 'error',
     'prefer-template': 'error',
     'quote-props': ['error', 'as-needed'],
     'space-before-blocks': 'error',
-    'space-before-function-paren': ['error', 'never'],
+    'space-before-function-paren': [
+      'error',
+      { anonymous: 'never', named: 'never', asyncArrow: 'always' }
+    ],
     'space-in-parens': 'error',
     quotes: 'error',
-    semi: 'error'
+    semi: 'error',
+    indent: 'off'
   }
 };

--- a/packages/eslint-config-yc-react/README.md
+++ b/packages/eslint-config-yc-react/README.md
@@ -17,7 +17,7 @@ It inherits some basic packages like:
   ```
   module.exports = {
     extends: [
-      'yc-react'
+      '@youngcapital/eslint-config-yc-react'
     ]
   };
   ```
@@ -25,7 +25,7 @@ It inherits some basic packages like:
   ```
   {
     "eslintConfig": {
-      "extends": "yc-react"
+      "extends": "@youngcapital/eslint-config-yc-react"
     }
   }
   ```
@@ -34,4 +34,8 @@ It inherits some basic packages like:
 
 ## Using the .prettierrc.js in your project
 
-You can use the same config as yc-base has [here](../eslint-config-yc-base/README.md#using-the-.prettierrc.js-in-your-project)
+In your project you can symlink to the yc-base prettierrc using the following command:
+
+```ln -s node_modules/eslint-config-yc-base/.prettierrc.js ./.prettierrc.js```
+
+This will allow your editor prettier integration to use our prettier configuration.

--- a/packages/eslint-config-yc-react/package.json
+++ b/packages/eslint-config-yc-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@youngcapital/eslint-config-yc-react",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "main": "index.js",
   "author": "YoungCapital",
   "license": "ISC",
@@ -16,7 +16,7 @@
   "dependencies": {
     "babel-eslint": "^10.0.1",
     "eslint-config-airbnb": "^17.1.0",
-    "eslint-config-yc-base": "^1.0.0",
+    "@youngcapital/eslint-config-yc-base": "^1.2.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^22.1.3",
     "eslint-plugin-jsx-a11y": "^6.1.2",


### PR DESCRIPTION
- The README's needed updating for the newly published package.
- There were a few conflicts between Prettier and ESlint that we wanted to deal with for a while now.
- The projects that we had that were using the linter, had a few extra rules that I now included in the rules for the base package.