### PR TITLE
Enable reportUnusedDisableDirectives option in eslint config

### DIFF
--- a/packages/eslint-config-yc-base/index.js
+++ b/packages/eslint-config-yc-base/index.js
@@ -11,5 +11,6 @@ module.exports = {
   ]
     .map(require.resolve)
     .concat(['plugin:jest/recommended']),
-  plugins: ['jest', 'prettier']
+  plugins: ['jest', 'prettier'],
+  reportUnusedDisableDirectives: true
 };


### PR DESCRIPTION
This PR updates eslint config so that it will report (with warnings) for unused `eslint-disable` directives.

This config option is only available since eslint version 6.3.
Unfortunately we are still using ^5.12.0 🤦 
That's why the base branch here is not master.
There is [another PR](https://github.com/youngcapital/yc-linter/pull/9) with versions upgrades.