### PR TITLE
Upgrade prettier

### DIFF
--- a/packages/eslint-config-yc-base/.prettierrc.js
+++ b/packages/eslint-config-yc-base/.prettierrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   singleQuote: true,
-  jsxSingleQuote: true
+  jsxSingleQuote: true,
+  trailingComma: 'none',
+  arrowParens: 'avoid',
+  endOfLine: 'auto'
 };

--- a/packages/eslint-config-yc-base/package.json
+++ b/packages/eslint-config-yc-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@youngcapital/eslint-config-yc-base",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "index.js",
   "author": "YoungCapital",
   "license": "ISC",
@@ -21,10 +21,10 @@
   },
   "peerDependencies": {
     "eslint": "^6.8.0",
-    "prettier": "^1.13.0"
+    "prettier": "^2.1.1"
   },
   "devDependencies": {
     "eslint": "^6.8.0",
-    "prettier": "^1.13.0"
+    "prettier": "^2.1.1"
   }
 }

--- a/packages/eslint-config-yc-base/yarn.lock
+++ b/packages/eslint-config-yc-base/yarn.lock
@@ -1038,10 +1038,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.13.0:
-  version "1.19.1"
-  resolved "https://npm.staging.nxdev.nl/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.1.1:
+  version "2.1.1"
+  resolved "https://npm.staging.nxdev.nl/prettier/-/prettier-2.1.1.tgz#d9485dd5e499daa6cb547023b87a6cf51bee37d6"
+  integrity sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==
 
 progress@^2.0.0:
   version "2.0.3"


### PR DESCRIPTION
This year prettier turned `^2.0`.

Probably it is time already for us to upgrade it.
Changes in this PR:
 - upgrade prettier version
 - bump up package version (the intention was to bring no changes for users, so only `patch` part of the version has been changed)
 - update prettier config so it preserves the "old" (pre 2.0) prettier's behaviour