### PR TITLE
Proposal: new prettier rules

### DIFF
--- a/packages/eslint-config-yc-base/.eslintrc.js
+++ b/packages/eslint-config-yc-base/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: "./index.js"
+  extends: './index.js',
 };

--- a/packages/eslint-config-yc-base/.git-blame-ignore-revs
+++ b/packages/eslint-config-yc-base/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Apply updated prettier rules (https://github.com/youngcapital/yc-linter/pull/15/files/09a5b883dfe5cd872e01621e4f7803ce45842a04)
+e1a443c3e9cefcb61e4be02ce4c45eaf3f4222d7

--- a/packages/eslint-config-yc-base/.prettierrc.js
+++ b/packages/eslint-config-yc-base/.prettierrc.js
@@ -1,5 +1,4 @@
 module.exports = {
   singleQuote: true,
   jsxSingleQuote: true,
-  endOfLine: 'auto',
 };

--- a/packages/eslint-config-yc-base/.prettierrc.js
+++ b/packages/eslint-config-yc-base/.prettierrc.js
@@ -1,6 +1,5 @@
 module.exports = {
   singleQuote: true,
   jsxSingleQuote: true,
-  arrowParens: 'avoid',
   endOfLine: 'auto',
 };

--- a/packages/eslint-config-yc-base/.prettierrc.js
+++ b/packages/eslint-config-yc-base/.prettierrc.js
@@ -1,7 +1,6 @@
 module.exports = {
   singleQuote: true,
   jsxSingleQuote: true,
-  trailingComma: 'none',
   arrowParens: 'avoid',
-  endOfLine: 'auto'
+  endOfLine: 'auto',
 };

--- a/packages/eslint-config-yc-base/README.md
+++ b/packages/eslint-config-yc-base/README.md
@@ -42,3 +42,10 @@ ln -s node_modules/@youngcapital/eslint-config-yc-base/.prettierrc.js ./.prettie
 ```
 
 This will allow your editor prettier integration to use our prettier configuration.
+
+## Migrations
+
+### to v.3
+
+After upgrading your project to use v.3 of `@youngcapital/eslint-config-yc-base` you'll probably want to reformat the code in your repository.  
+Please follow [this article](https://www.moxio.com/blog/43/ignoring-bulk-change-commits-with-git-blame) to achieve it in the least painful way.

--- a/packages/eslint-config-yc-base/index.js
+++ b/packages/eslint-config-yc-base/index.js
@@ -1,16 +1,16 @@
 module.exports = {
   env: {
     es6: true,
-    'jest/globals': true
+    'jest/globals': true,
   },
   extends: [
     'eslint-config-airbnb-base',
     'eslint-config-airbnb-base/rules/strict',
     './rules/rules',
-    './rules/prettier'
+    './rules/prettier',
   ]
     .map(require.resolve)
     .concat(['plugin:jest/recommended']),
   plugins: ['jest', 'prettier'],
-  reportUnusedDisableDirectives: true
+  reportUnusedDisableDirectives: true,
 };

--- a/packages/eslint-config-yc-base/package.json
+++ b/packages/eslint-config-yc-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@youngcapital/eslint-config-yc-base",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "main": "index.js",
   "author": "YoungCapital",
   "license": "ISC",

--- a/packages/eslint-config-yc-base/rules/prettier.js
+++ b/packages/eslint-config-yc-base/rules/prettier.js
@@ -5,6 +5,6 @@ const prettierConfig = require(path.resolve(__dirname, '../.prettierrc.js'));
 
 module.exports = {
   rules: {
-    'prettier/prettier': ['error', prettierConfig]
-  }
+    'prettier/prettier': ['error', prettierConfig],
+  },
 };

--- a/packages/eslint-config-yc-base/rules/rules.js
+++ b/packages/eslint-config-yc-base/rules/rules.js
@@ -36,11 +36,11 @@ module.exports = {
     'space-before-blocks': 'error',
     'space-before-function-paren': [
       'error',
-      { anonymous: 'never', named: 'never', asyncArrow: 'always' }
+      { anonymous: 'never', named: 'never', asyncArrow: 'always' },
     ],
     'space-in-parens': 'error',
     quotes: 'error',
     semi: 'error',
-    indent: 'off'
-  }
+    indent: 'off',
+  },
 };


### PR DESCRIPTION
Here are some proposals for prettier configuration.
Changes here will move us from default values which were in prettier pre-2.0 to new default values.
Also please check [prettier-upgrade PR](https://github.com/youngcapital/yc-linter/pull/13).

Relates to each proposal: I believe the fact that new values are default ones already is a strong reason to consider using it. Still I've applied some rationales to make it even more reasonable :)

---

[Trailing Commas](https://prettier.io/docs/en/options.html#trailing-commas): `none` -> `es5`.
There is [a good article](https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8) about that. In short: better diffs and easier code writing.
Compare:
without trailing comma
![](https://miro.medium.com/max/1000/1*U7YPRg8LXs2SM2z1t76p_w.png)
with trailing comma
![](https://miro.medium.com/max/1000/1*oW4T7ZMBK3DNRFU6H0m7Dw.png)

[Arrow Function Parentheses](https://prettier.io/docs/en/options.html#arrow-function-parentheses): `avoid` -> `always`
[Official release log](https://prettier.io/blog/2020/03/21/2.0.0.html#change-default-value-for-arrowparens-to-always-7430httpsgithubcomprettierprettierpull7430-by-kachkaevhttpsgithubcomkachkaev) has a pretty good explanation about why this may be helpful. In short: consistency, easier code writing (adding more parameters, default values etc.)
Compare:
`{ "arrowParens": "avoid" }`
<img width="233" alt="image" src="https://user-images.githubusercontent.com/1935066/91849570-90e08100-ec5c-11ea-96b4-c7570eb1eb42.png">
`{ "arrowParens": "always" }`
<img width="234" alt="image" src="https://user-images.githubusercontent.com/1935066/91849636-a3f35100-ec5c-11ea-8039-647835745ba4.png">

[End of line](https://prettier.io/blog/2020/03/21/2.0.0.html#change-default-value-for-endofline-to-lf-7435httpsgithubcomprettierprettierpull7435-by-kachkaevhttpsgithubcomkachkaev): `auto` -> `lf`
I believe all of us are using macOS or some other sort of Unix OS.
Our CI tools are also running inside such OSs.
Let's just use `LF` as a rule?

---

#16 must be merged into this PR first, before this branch can be merged into `master`.